### PR TITLE
perf: faster log deletion

### DIFF
--- a/server_performance/server_performance/doctype/server_performance_log/server_performance_log.py
+++ b/server_performance/server_performance/doctype/server_performance_log/server_performance_log.py
@@ -11,4 +11,4 @@ class ServerPerformanceLog(Document):
 	@staticmethod
 	def clear_old_logs(days=90):
 		table = frappe.qb.DocType("Server Performance Log")
-		frappe.db.delete(table, filters=(table.creation < (Now() - Interval(days=days))))
+		frappe.db.delete(table, filters=(table.modified < (Now() - Interval(days=days))))


### PR DESCRIPTION
`modified` column is indexed by default on doctypes (for list views) so deleting using the modified column is much faster as data grows. 

For logs: modified ~= creation. So it's correct.